### PR TITLE
TAO-10245 splited the resources into different indexes, indexing dina…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "GPL-2.0-only"
   ],
   "require" : {
-    "php" : ">=5.3.10",
+    "php" : ">=7.1",
     "oat-sa/tao-core" : ">=18.1.0||dev-develop",
     "elasticsearch/elasticsearch": "~6.0"
   },

--- a/src/ElasticSearch.php
+++ b/src/ElasticSearch.php
@@ -55,7 +55,7 @@ class ElasticSearch extends ConfigurableService implements Search
 
     protected function getIndexer(): ElasticSearchIndexer
     {
-        return new ElasticSearchIndexer($this->getClient());
+        return new ElasticSearchIndexer($this->getClient(), $this->getLogger());
     }
 
     /**

--- a/src/ElasticSearchIndexer.php
+++ b/src/ElasticSearchIndexer.php
@@ -17,10 +17,13 @@
  * Copyright (c) 2018 (original work) Open Assessment Technologies SA;
  */
 
+declare(strict_types=1);
+
 namespace oat\tao\elasticsearch;
 
-use Iterator;
 use Elasticsearch\Client;
+use RuntimeException;
+use Iterator;
 use oat\tao\model\search\index\IndexDocument;
 
 /**
@@ -29,98 +32,85 @@ use oat\tao\model\search\index\IndexDocument;
  */
 class ElasticSearchIndexer implements IndexerInterface
 {
-    const INDEXING_BLOCK_SIZE = 100;
+    private const INDEXING_BLOCK_SIZE = 100;
 
-    /** @var Client|null  */
-    private $client = null;
+    /** @var Client */
+    private $client;
 
-    /** @var string */
-    private $index;
-
-    /** @var string */
-    private $type;
-
-    /**
-     * ElasticSearchIndexer constructor.
-     * @param Client $client
-     * @param string $index
-     * @param string $type
-     */
-    public function __construct(Client $client, $index = 'documents', $type = 'document')
+    public function __construct(Client $client)
     {
         $this->client = $client;
-        $this->index = $index;
-        $this->type = $type;
     }
 
-    /**
-     * @return string
-     */
-    public function getIndex()
-    {
-        return $this->index;
-    }
-
-    /**
-     * @return string
-     */
-    public function getType()
-    {
-        return $this->type;
-    }
-
-    /**
-     * @return Client|null
-     */
-    protected function getClient()
+    protected function getClient(): Client
     {
         return $this->client;
     }
 
+    public function getIndexNameByDocument(IndexDocument $document): string
+    {
+        $documentBody = $document->getBody();
+
+        if (!isset($documentBody['type'])) {
+            throw new RuntimeException('type property is undefined on the document');
+        }
+
+        $documentType = $documentBody['type'];
+
+        foreach (self::AVAILABLE_INDEXES as $ontology => $indexName) {
+            if (in_array($ontology, $documentType)) {
+                return $indexName;
+            }
+        }
+
+        return self::UNCLASSIFIEDS_DOCUMENTS_INDEX;
+    }
+
     /**
      * @param Iterator $documents
-     * @return int
+     * @return int The number of indexed documents
      */
-    public function buildIndex(Iterator $documents)
+    public function buildIndex(Iterator $documents): int
     {
         $count = 0;
+        $blockSize = 0;
+        $params = [];
+
         while ($documents->valid()) {
-            $blockSize = 0;
-            $params = ['body' => []];
+            /** @var IndexDocument $document */
+            $document = $documents->current();
 
-            while ($documents->valid() && $blockSize < self::INDEXING_BLOCK_SIZE) {
-                /** @var IndexDocument $document */
-                $document = $documents->current();
+            // First step we trying to create document. If is exist, then skip this step
+            $indexName = $this->getIndexNameByDocument($document);
 
-                // First step we trying to create document. If is exist, then skip this step
-                $params['body'][] = [
-                    'create' => [
-                        '_index' => $this->getIndex(),
-                        '_type' => $this->getType(),
-                        '_id' => $document->getId()
-                    ]
-                ];
+            if ($indexName === self::UNCLASSIFIEDS_DOCUMENTS_INDEX) {
+                \common_Logger::i(sprintf('There is no proper index for the document "%s"', $document->getId()));
 
-                $params['body'][] = $document->getBody();
-
-                // Trying to update document
-                $params['body'][] = [
-                    'update' => [
-                        '_index' => $this->getIndex(),
-                        '_type' => $this->getType(),
-                        '_id' => $document->getId()
-                    ]
-                ];
-
-                $params['body'][]['doc'] = $document->getBody();
                 $documents->next();
-                $blockSize++;
+                continue;
             }
-            if ($blockSize > 0) {
-                $responses = $this->client->bulk($params);
+
+            \common_Logger::i(sprintf('adding document "%s" to be indexed', $document->getId()));
+
+            $params = $this->extendBatch('delete', $indexName, $document, $params);
+            $params = $this->extendBatch('create', $indexName, $document, $params);
+            $params = $this->extendBatch('update', $indexName, $document, $params);
+
+            $documents->next();
+
+            $blockSize++;
+
+            if ($blockSize === self::INDEXING_BLOCK_SIZE) {
+                $this->client->bulk($params);
                 $count += $blockSize;
-                unset($responses);
+                $blockSize = 0;
+                $params = [];
             }
+        }
+
+        if ($blockSize > 0) {
+            $this->client->bulk($params);
+            $count += $blockSize;
         }
 
         return $count;
@@ -130,14 +120,13 @@ class ElasticSearchIndexer implements IndexerInterface
      * @param $id
      * @return bool
      */
-    public function deleteIndex($id)
+    public function deleteDocument($id): bool
     {
         $document = $this->searchResourceByIds([$id]);
 
         if ($document) {
             $deleteParams = [
                 'index' => $document['_index'],
-                'type' => $document['_type'],
                 'id' => $document['_id']
             ];
             $this->getClient()->delete($deleteParams);
@@ -149,7 +138,7 @@ class ElasticSearchIndexer implements IndexerInterface
     }
 
     /**
-     * @param array  $ids
+     * @param array $ids
      * @param string $type
      * @return array
      */
@@ -176,5 +165,36 @@ class ElasticSearchIndexer implements IndexerInterface
         }
 
         return $document;
+    }
+
+    /**
+     * @param string $indexName
+     * @param IndexDocument $document
+     * @param array $params
+     *
+     * @return array
+     */
+    private function extendBatch(string $action, string $indexName, IndexDocument $document, array $params): array
+    {
+        $params['body'][] = [
+            $action => [
+                '_index' => $indexName,
+                '_id' => $document->getId()
+            ]
+        ];
+
+        if ('delete' === $action) {
+            return $params;
+        }
+
+        $body = array_merge($document->getBody(), (array)$document->getDynamicProperties());
+
+        if ($action === 'update') {
+            $body = ['doc' => $body];
+        }
+
+        $params['body'][] = $body;
+
+        return $params;
     }
 }

--- a/src/ElasticSearchIndexer.php
+++ b/src/ElasticSearchIndexer.php
@@ -22,6 +22,7 @@ declare(strict_types=1);
 namespace oat\tao\elasticsearch;
 
 use Elasticsearch\Client;
+use Psr\Log\LoggerInterface;
 use RuntimeException;
 use Iterator;
 use oat\tao\model\search\index\IndexDocument;
@@ -37,9 +38,13 @@ class ElasticSearchIndexer implements IndexerInterface
     /** @var Client */
     private $client;
 
-    public function __construct(Client $client)
+    /** @var LoggerInterface */
+    private $logger;
+
+    public function __construct(Client $client, LoggerInterface $logger)
     {
         $this->client = $client;
+        $this->logger = $logger;
     }
 
     protected function getClient(): Client
@@ -84,13 +89,13 @@ class ElasticSearchIndexer implements IndexerInterface
             $indexName = $this->getIndexNameByDocument($document);
 
             if ($indexName === self::UNCLASSIFIEDS_DOCUMENTS_INDEX) {
-                \common_Logger::i(sprintf('There is no proper index for the document "%s"', $document->getId()));
+                $this->logger->info(sprintf('There is no proper index for the document "%s"', $document->getId()));
 
                 $documents->next();
                 continue;
             }
 
-            \common_Logger::i(sprintf('adding document "%s" to be indexed', $document->getId()));
+            $this->logger->info(sprintf('adding document "%s" to be indexed', $document->getId()));
 
             $params = $this->extendBatch('delete', $indexName, $document, $params);
             $params = $this->extendBatch('create', $indexName, $document, $params);

--- a/src/IndexerInterface.php
+++ b/src/IndexerInterface.php
@@ -17,45 +17,67 @@
  * Copyright (c) 2018 (original work) Open Assessment Technologies SA;
  */
 
+declare(strict_types=1);
+
 namespace oat\tao\elasticsearch;
 
 use Iterator;
+use oat\tao\model\search\index\IndexDocument;
+use oat\tao\model\TaoOntology;
 
 /**
  * Interface IndexerInterface
  */
 interface IndexerInterface
 {
-    /**
-     * Returns name of current using index
-     * @return mixed
-     */
-    public function getIndex();
+    public const ITEMS_INDEX = 'items';
+    public const TESTS_INDEX = 'tests';
+    public const TEST_TAKERS_INDEX = 'test-takers';
+    public const DELIVERIES_INDEX = 'deliveries';
+    public const GROUPS_INDEX = 'groups';
+    public const UNCLASSIFIEDS_DOCUMENTS_INDEX = 'unclassifieds';
+    public const AVAILABLE_INDEXES = [
+        TaoOntology::CLASS_URI_ITEM => self::ITEMS_INDEX,
+        TaoOntology::CLASS_URI_TEST => self::TESTS_INDEX,
+        TaoOntology::CLASS_URI_SUBJECT => self::TEST_TAKERS_INDEX,
+        TaoOntology::CLASS_URI_DELIVERY => self::DELIVERIES_INDEX,
+        TaoOntology::CLASS_URI_GROUP => self::GROUPS_INDEX
+    ];
 
     /**
-     * Returns name if current using type
-     * @return mixed
+     * Returns name of current using index
+     *
+     * @throws \Throwable
+     *
+     * @return string
      */
-    public function getType();
+    public function getIndexNameByDocument(IndexDocument $document): string;
 
     /**
      * Builds index for a given resources
+     *
      * @param Iterator $resources
-     * @return mixed
+     *
+     * @return int
      */
-    public function buildIndex(Iterator $resources);
+    public function buildIndex(Iterator $resources): int;
 
     /**
      * Deletes data from index for a resources with a given id
+     *
      * @param $id
-     * @return mixed
+     *
+     * @return bool
      */
-    public function deleteIndex($id);
+    public function deleteDocument($id): bool;
 
     /**
      * Searches and returns resources that matches a given list of identifiers
+     * 
      * @param $ids array List of identifiers
+     *
      * @param $type string Type of resources
+     *
      * @return mixed
      */
     public function searchResourceByIds($ids, $type);


### PR DESCRIPTION
- Instead of using just one index (documents), now we have one index for each resource (item, groups, tests, test-takers, deliveries, ...)
- Removed _type property (it's deprecated on the new elastic search version)
- Automatic index custom class properties
- Added Info logs when populating the index.