### PR TITLE
Feature/tao 10285 property removal event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ CHANGELOG
 - Class properties automatically indexed
 - Creted separated indexes for Items, Tests, Test-Takers, Groups and Deliveries
 - Added a query builder to handle searches on different indexes
-- Updated indexes when custom properties are changed using IndexUpdater Interface.
+- Updated indexes when custom properties are changed/deleted using IndexUpdater Interface.
 
 1.1.1
 -----

--- a/src/Exception/FailToRemovePropertyException.php
+++ b/src/Exception/FailToRemovePropertyException.php
@@ -21,12 +21,12 @@
 
 declare(strict_types=1);
 
-namespace oat\tao\elasticsearch;
+namespace oat\tao\elasticsearch\Exception;
 
 use Exception;
 use Throwable;
 
-class FailToUpdatePropertiesException extends Exception
+class FailToRemovePropertyException extends Exception
 {
     public function __construct(string $message = '', int $code = 0, Throwable $previous = null)
     {

--- a/src/Exception/FailToUpdatePropertiesException.php
+++ b/src/Exception/FailToUpdatePropertiesException.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA;
+ *
+ *
+ */
+
+declare(strict_types=1);
+
+namespace oat\tao\elasticsearch\Exception;
+
+use Exception;
+use Throwable;
+
+class FailToUpdatePropertiesException extends Exception
+{
+    public function __construct(string $message = '', int $code = 0, Throwable $previous = null)
+    {
+        parent::__construct(
+            sprintf(
+                'Error During Update the Properties %s. Please, check previous exception for more details.',
+                $message
+            ),
+            $code,
+            $previous
+        );
+    }
+}

--- a/src/IndexUpdater.php
+++ b/src/IndexUpdater.php
@@ -86,15 +86,15 @@ class IndexUpdater extends ConfigurableService implements IndexUpdaterInterface
             return;
         }
 
-        $result = implode(' ', array_merge($queryNewProperty, $queryRemoveOldProperty));
+        $script = implode(' ', array_merge($queryNewProperty, $queryRemoveOldProperty));
 
         try {
-            $this->executeUpdateQuery($index, $type, $result);
+            $this->executeUpdateQuery($index, $type, $script);
         } catch (Throwable $e) {
             throw new FailToUpdatePropertiesException(
                 sprintf(
                     'by script: %s AND type: %s',
-                    $result,
+                    $script,
                     $type
                 ),
                 $e->getCode(),
@@ -122,7 +122,7 @@ class IndexUpdater extends ConfigurableService implements IndexUpdaterInterface
             throw new FailToRemovePropertyException(
                 sprintf(
                     'by script: %s AND type: %s',
-                    $result,
+                    $script,
                     $type
                 ),
                 $e->getCode(),

--- a/src/IndexUpdater.php
+++ b/src/IndexUpdater.php
@@ -106,10 +106,18 @@ class IndexUpdater extends ConfigurableService implements IndexUpdaterInterface
     public function deleteProperty(array $property): void
     {
         $name = $property['name'];
-        $parentClasses = $property['parentClasses'];
         $type = $property['type'];
+        $parentClasses = $property['parentClasses'];
+
+        if (empty($name) || empty($type)) {
+            return;
+        }
 
         $index = $this->findIndex($parentClasses, $type);
+
+        if ($index === IndexerInterface::UNCLASSIFIEDS_DOCUMENTS_INDEX) {
+            return;
+        }
 
         $script = sprintf(
             'ctx._source.remove(\'%s\');',

--- a/src/IndexUpdater.php
+++ b/src/IndexUpdater.php
@@ -24,8 +24,6 @@ declare(strict_types=1);
 
 namespace oat\tao\elasticsearch;
 
-use core_kernel_classes_Class;
-use core_kernel_classes_Property;
 use Elasticsearch\Client;
 use Elasticsearch\ClientBuilder;
 use oat\generis\model\WidgetRdf;
@@ -120,22 +118,17 @@ class IndexUpdater extends ConfigurableService implements IndexUpdaterInterface
         }
     }
 
-    public function deleteProperty(core_kernel_classes_Class $class, core_kernel_classes_Property $property): void
+    public function deleteProperty(array $property): void
     {
-        $type = $class->getUri();
-        $parentClasses = array_map(function($currentClass) {
-            return $currentClass->getUri();
-        }, $class->getParentClasses(true));
+        $name = $property['name'];
+        $parentClasses = $property['parentClasses'];
+        $type = $property['type'];
 
         $index = $this->findIndex($parentClasses, $type);
 
-        $propertyType = $property->getOnePropertyValue(new core_kernel_classes_Property(WidgetRdf::PROPERTY_WIDGET));
-        $propertyType = parse_url($propertyType->getUri());
-
         $script = sprintf(
-            'ctx._source.remove(\'%s_%s\');',
-            $propertyType['fragment'],
-            $property->getLabel()
+            'ctx._source.remove(\'%s\');',
+            $name
         );
 
         try {

--- a/src/IndexUpdater.php
+++ b/src/IndexUpdater.php
@@ -118,6 +118,12 @@ class IndexUpdater extends ConfigurableService implements IndexUpdaterInterface
         }
     }
 
+    public function deleteProperty(string $propertyName, array $resources): void
+    {
+        $debug = true;
+    }
+
+
     private function findIndex(array $parentClasses, string $type): string
     {
         if (isset(IndexerInterface::AVAILABLE_INDEXES[$type])) {

--- a/src/IndexUpdater.php
+++ b/src/IndexUpdater.php
@@ -24,6 +24,8 @@ declare(strict_types=1);
 
 namespace oat\tao\elasticsearch;
 
+use core_kernel_classes_Class;
+use core_kernel_classes_Property;
 use Elasticsearch\Client;
 use Elasticsearch\ClientBuilder;
 use oat\generis\model\WidgetRdf;
@@ -118,7 +120,7 @@ class IndexUpdater extends ConfigurableService implements IndexUpdaterInterface
         }
     }
 
-    public function deleteProperty(string $propertyName, array $resources): void
+    public function deleteProperty(core_kernel_classes_Class $class, core_kernel_classes_Property $property): void
     {
         $debug = true;
     }

--- a/test/IndexUpdaterTest.php
+++ b/test/IndexUpdaterTest.php
@@ -148,7 +148,8 @@ class IndexUpdaterTest extends TestCase
         $this->sut->deleteProperty($property);
     }
 
-    public function testExceptionWhenRemovingProperty(): void {
+    public function testExceptionWhenRemovingProperty(): void
+    {
         $this->expectException(FailToRemovePropertyException::class);
 
         $this->client->expects($this->once())

--- a/test/IndexUpdaterTest.php
+++ b/test/IndexUpdaterTest.php
@@ -25,8 +25,9 @@ namespace oat\tao\test\elasticsearch;
 
 use Elasticsearch\Client;
 use Elasticsearch\Common\Exceptions\BadMethodCallException;
-use oat\tao\elasticsearch\FailToUpdatePropertiesException;
 use oat\generis\test\TestCase;
+use oat\tao\elasticsearch\Exception\FailToUpdatePropertiesException;
+use oat\tao\elasticsearch\Exception\FailToRemovePropertyException;
 use oat\tao\elasticsearch\IndexUpdater;
 use oat\tao\model\TaoOntology;
 use ReflectionObject;
@@ -58,9 +59,9 @@ class IndexUpdaterTest extends TestCase
     }
 
     /**
-     * @dataProvider provideValidProperties
+     * @dataProvider provideValidPropertiesForUpdate
      */
-    public function testUpdatePropertiesSuccessfull(array $properties, string $source): void
+    public function testUpdatePropertiesSuccessfully(array $properties, string $source): void
     {
         $this->client->expects($this->once())
             ->method('updateByQuery')
@@ -87,7 +88,7 @@ class IndexUpdaterTest extends TestCase
         );
     }
 
-    public function testClientException(): void {
+    public function testExceptionWhenUpdatingProperties(): void {
         $this->expectException(FailToUpdatePropertiesException::class);
 
         $this->client->expects($this->once())
@@ -107,7 +108,7 @@ class IndexUpdaterTest extends TestCase
     }
 
     /**
-     * @dataProvider provideInvalidProperties
+     * @dataProvider provideInvalidPropertiesForUpdate
      */
     public function testDoNotUpdateProperties(array $properties): void
     {
@@ -119,7 +120,62 @@ class IndexUpdaterTest extends TestCase
         );
     }
 
-    public function provideValidProperties(): array
+    /**
+     * @dataProvider provideValidPropertiesForRemoval
+     */
+    public function testRemovePropertySuccessfully(array $property, string $source): void
+    {
+        $this->client->expects($this->once())
+            ->method('updateByQuery')
+            ->with(
+                [
+                    'index' => 'items',
+                    'type' => '_doc',
+                    'conflicts' => 'proceed',
+                    'wait_for_completion' => true,
+                    'body' => [
+                        'query' => [
+                            'match' => [
+                                'type' => TaoOntology::CLASS_URI_ITEM
+                            ]
+                        ],
+                        'script' => [
+                            'source' => $source
+                        ]
+                    ]
+                ]
+            );
+        $this->sut->deleteProperty($property);
+    }
+
+    public function testExceptionWhenRemovingProperty(): void {
+        $this->expectException(FailToRemovePropertyException::class);
+
+        $this->client->expects($this->once())
+            ->method('updateByQuery')
+            ->willThrowException(new BadMethodCallException());
+
+        $this->sut->deleteProperty(
+            [
+                'name' => 'test',
+                'parentClasses' => ['someClass'],
+                'type' => TaoOntology::CLASS_URI_ITEM
+            ]
+        );
+    }
+
+    /**
+     * @dataProvider provideInvalidPropertiesForRemoval
+     */
+    public function testDoNotRemoveProperty(array $property): void
+    {
+        $this->client->expects($this->never())
+            ->method('updateByQuery');
+
+        $this->sut->deleteProperty($property);
+    }
+
+    public function provideValidPropertiesForUpdate(): array
     {
         return [
             'Single' => [
@@ -155,7 +211,7 @@ class IndexUpdaterTest extends TestCase
         ];
     }
 
-    public function provideInvalidProperties(): array
+    public function provideInvalidPropertiesForUpdate(): array
     {
         return [
             'With No OldName' => [
@@ -209,6 +265,55 @@ class IndexUpdaterTest extends TestCase
                         ]
                     ]
             ],
+        ];
+    }
+
+    public function provideValidPropertiesForRemoval(): array
+    {
+        return [
+            [
+                'property' => [
+                    'name' => 'prop1',
+                    'parentClasses' => [],
+                    'type' => TaoOntology::CLASS_URI_ITEM
+                ],
+                'source' => 'ctx._source.remove(\'prop1\');'
+            ],
+            [
+                'property' => [
+                    'name' => 'prop2',
+                    'parentClasses' => [],
+                    'type' => TaoOntology::CLASS_URI_ITEM
+                ],
+                'source' => 'ctx._source.remove(\'prop2\');'
+            ],
+        ];
+    }
+
+    public function provideInvalidPropertiesForRemoval(): array
+    {
+        return [
+            'with no name' => [
+                'property' => [
+                    'name' => '',
+                    'parentClasses' => [],
+                    'type' => TaoOntology::CLASS_URI_ITEM
+                ]
+            ],
+            'with no type' => [
+                'property' => [
+                    'name' => 'prop',
+                    'parentClasses' => [],
+                    'type' => ''
+                ]
+            ],
+            'with invalid type' => [
+                'property' => [
+                    'name' => 'prop',
+                    'parentClasses' => [],
+                    'type' => 'invalid'
+                ]
+            ]
         ];
     }
 }


### PR DESCRIPTION
The goal with these changes is to handle the ElasticSearch operation to remove the class property on any already indexed document matching the conditions

- Added method for removal on IndexUpdater
- Moved query execution to separated method
- Added exclusive exception for Removal operation