### PR TITLE
fix: Use generis search in case of unsupported types, add new method …

### DIFF
--- a/src/Action/InitElasticSearch.php
+++ b/src/Action/InitElasticSearch.php
@@ -28,6 +28,7 @@ use oat\tao\elasticsearch\Watcher\IndexDocumentFactory;
 use oat\tao\model\search\index\IndexService;
 use oat\tao\elasticsearch\IndexUpdater;
 use oat\tao\model\search\index\IndexUpdaterInterface;
+use oat\tao\model\search\strategy\GenerisSearch;
 use oat\tao\model\search\SyntaxException;
 use oat\oatbox\extension\InstallAction;
 use oat\tao\model\search\Search;
@@ -127,14 +128,16 @@ class InitElasticSearch extends InstallAction
             $config['settings'] = $oldSettings['settings'];
         }
 
+        $config[GenerisSearch::class] = new GenerisSearch();
+
         try {
             $search = new ElasticSearch($config);
 
             $search->createIndexes();
             $this->getServiceManager()->register(Search::SERVICE_ID, $search);
-            
+
             $report->add(new Report(Report::TYPE_SUCCESS, __('Switched search service implementation to ElasticSearch')));
-            
+
             $this->getServiceManager()->register(IndexUpdaterInterface::SERVICE_ID, new IndexUpdater($config['hosts']));
         } catch (BadRequest400Exception $e) {
             $report->add(new Report(Report::TYPE_ERROR, 'Unable to create index: ' . $e->getMessage()));

--- a/src/ElasticSearch.php
+++ b/src/ElasticSearch.php
@@ -83,7 +83,7 @@ class ElasticSearch extends ConfigurableService implements Search
      * @return ResultSet
      * @throws SyntaxException
      */
-    public function query($queryString, $type, $start = 0, $count = 10, $order = '_id', $dir = 'DESC')
+    public function query($queryString, $type, $start = 0, $count = 10, $order = '_id', $dir = 'DESC'): ResultSet
     {
         if (!isset(IndexerInterface::AVAILABLE_INDEXES[$type])) {
             return $this->getGenerisSearch()->query($queryString, $type, $start, $count, $order, $dir);

--- a/src/ElasticSearch.php
+++ b/src/ElasticSearch.php
@@ -27,6 +27,7 @@ use Elasticsearch\ClientBuilder;
 use Iterator;
 use oat\tao\model\search\index\IndexIterator;
 use oat\tao\model\search\Search;
+use oat\tao\model\search\strategy\GenerisSearch;
 use oat\tao\model\search\SyntaxException;
 use oat\tao\model\search\ResultSet;
 use oat\oatbox\service\ConfigurableService;
@@ -56,6 +57,7 @@ class ElasticSearch extends ConfigurableService implements Search
         return $this->client;
     }
 
+
     /** @return QueryBuilder */
     protected function getQueryBuilder(): QueryBuilder
     {
@@ -83,6 +85,10 @@ class ElasticSearch extends ConfigurableService implements Search
      */
     public function query($queryString, $type, $start = 0, $count = 10, $order = '_id', $dir = 'DESC')
     {
+        if (!isset(IndexerInterface::AVAILABLE_INDEXES[$type])) {
+            return $this->getGenerisSearch()->query($queryString, $type, $start, $count, $order, $dir);
+        }
+
         if ($order == 'id') {
             $order = '_id';
         }
@@ -100,7 +106,10 @@ class ElasticSearch extends ConfigurableService implements Search
             switch ($exception->getCode()) {
                 case 400:
                     $json = json_decode($exception->getMessage(), true);
-                    $message = __('There is an error in your search query, system returned: %s', $json['error']['reason']);
+                    $message = __(
+                        'There is an error in your search query, system returned: %s',
+                        $json['error']['reason']
+                    );
                     $this->getLogger()->error($message, [$exception->getMessage()]);
                     throw new SyntaxException($queryString, $message);
                 default:
@@ -148,12 +157,23 @@ class ElasticSearch extends ConfigurableService implements Search
 
     public function flush(): array
     {
-        return $this->getClient()->indices()->delete([
-            'index' => implode(',', IndexerInterface::AVAILABLE_INDEXES),
-            'client' => [
-                'ignore' => 404
+        return $this->getClient()->indices()->delete(
+            [
+                'index' => implode(',', IndexerInterface::AVAILABLE_INDEXES),
+                'client' => [
+                    'ignore' => 404
+                ]
             ]
-        ]);
+        );
+    }
+
+    private function getGenerisSearch(): GenerisSearch
+    {
+        /** @var GenerisSearch $generisSearch */
+        $generisSearch = $this->getOption(GenerisSearch::class);
+        $generisSearch->setServiceLocator($this->getServiceLocator());
+
+        return $generisSearch;
     }
 
     /**

--- a/src/IndexUpdater.php
+++ b/src/IndexUpdater.php
@@ -139,6 +139,11 @@ class IndexUpdater extends ConfigurableService implements IndexUpdaterInterface
         }
     }
 
+    public function hasClassSupport(string $class): bool
+    {
+        return isset(IndexerInterface::AVAILABLE_INDEXES[$class]);
+    }
+
     private function findIndex(array $parentClasses, string $type): string
     {
         if (isset(IndexerInterface::AVAILABLE_INDEXES[$type])) {

--- a/test/ElasticSearchTest.php
+++ b/test/ElasticSearchTest.php
@@ -1,0 +1,200 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA;
+ */
+declare(strict_types=1);
+
+namespace oat\tao\test\elasticsearch;
+
+use Elasticsearch\Client;
+use Exception;
+use oat\generis\test\TestCase;
+use oat\oatbox\log\LoggerService;
+use oat\tao\elasticsearch\ElasticSearch;
+use oat\tao\elasticsearch\IndexUpdater;
+use oat\tao\model\search\ResultSet;
+use oat\tao\model\search\strategy\GenerisSearch;
+use oat\tao\model\search\SyntaxException;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
+use ReflectionObject;
+
+class ElasticSearchTest extends TestCase
+{
+    /** @var ElasticSearch */
+    private $sut;
+
+    /** @var Client|MockObject */
+    private $client;
+
+    /** @var GenerisSearch|MockObject */
+    private $generisSearch;
+
+    /** @var LoggerInterface|MockObject */
+    private $logger;
+
+    protected function setUp(): void
+    {
+        $this->generisSearch = $this->createMock(
+            GenerisSearch::class
+        );
+
+        $this->sut = new ElasticSearch(
+            [
+                GenerisSearch::class => $this->generisSearch
+            ]
+        );
+
+        $this->client = $this->createMock(Client::class);
+        $this->logger = $this->createMock(LoggerInterface::class);
+
+        $serviceLocator = $this->getServiceLocatorMock(
+            [
+                LoggerService::SERVICE_ID => $this->logger,
+            ]
+        );
+
+        $this->sut->setServiceLocator($serviceLocator);
+
+        $reflection = new ReflectionObject($this->sut);
+        $clientProperty = $reflection->getProperty('client');
+        $clientProperty->setAccessible(true);
+        $clientProperty->setValue(
+            $this->sut,
+            $this->client
+        );
+    }
+
+    public function testQuery_callGenerisSearchCaseClassIsNotSupported(): void
+    {
+        $invalidType = 'https://tao.docker.localhost/ontologies/tao.rdf#Invalid';
+        $this->generisSearch->expects($this->once())
+            ->method('query')
+            ->with('item', $invalidType, 0, 10, '_id', 'DESC')
+            ->willReturn(
+                $this->createMock(ResultSet::class)
+            );
+
+        $this->sut->query('item', $invalidType);
+    }
+
+    public function testQuery_callElasticSearchCaseClassIsSupported(): void
+    {
+        $validType = 'http://www.tao.lu/Ontologies/TAOItem.rdf#Item';
+
+        $this->generisSearch->expects($this->never())
+            ->method('query');
+
+        $this->mockDebugLogger();
+
+        $documentUri = 'https://tao.docker.localhost/ontologies/tao.rdf#i5ef45f413088c8e7901a84708e84ec';
+
+        $this->client->expects($this->once())
+            ->method('search')
+            ->willReturn(
+                [
+                    'hits' => [
+                        'hits' => [
+                            [
+                                '_id' => $documentUri
+                            ]
+                        ],
+                        'total' => [
+                            'value' => 1
+                        ]
+                    ]
+                ]
+            );
+
+        $resultSet = $this->sut->query('item', $validType);
+
+        $this->assertEquals(new ResultSet([$documentUri], 1), $resultSet);
+    }
+
+    public function testQuery_callElasticSearchGenericError(): void
+    {
+        $this->expectException(SyntaxException::class);
+        $validType = 'http://www.tao.lu/Ontologies/TAOItem.rdf#Item';
+
+        $this->generisSearch->expects($this->never())
+            ->method('query');
+
+        $this->mockDebugLogger();
+
+        $this->logger->expects($this->once())
+            ->method('error')
+            ->with('An unknown error occured during search', ['']);
+
+        $documentUri = 'https://tao.docker.localhost/ontologies/tao.rdf#i5ef45f413088c8e7901a84708e84ec';
+
+        $this->client->expects($this->once())
+            ->method('search')
+            ->willThrowException(
+                new Exception()
+            );
+
+        $resultSet = $this->sut->query('item', $validType);
+    }
+
+    public function testQuery_callElasticSearch400Error(): void
+    {
+        $this->expectException(SyntaxException::class);
+        $validType = 'http://www.tao.lu/Ontologies/TAOItem.rdf#Item';
+
+        $this->generisSearch->expects($this->never())
+            ->method('query');
+
+        $this->mockDebugLogger();
+
+        $this->logger->expects($this->once())
+            ->method('error')
+            ->with(
+                'There is an error in your search query, system returned: Error',
+                [
+                    '{"error":{"reason": "Error"}}'
+                ]
+            );
+
+        $documentUri = 'https://tao.docker.localhost/ontologies/tao.rdf#i5ef45f413088c8e7901a84708e84ec';
+
+        $this->client->expects($this->once())
+            ->method('search')
+            ->willThrowException(
+                new Exception('{"error":{"reason": "Error"}}', 400)
+            );
+
+        $resultSet = $this->sut->query('item', $validType);
+    }
+
+    private function mockDebugLogger(): void
+    {
+        $this->logger->expects($this->once())->method('debug')->with(
+            'Query ',
+            [
+                'index' => 'items',
+                'size' => 10,
+                'from' => 0,
+                'client' =>
+                    [
+                        'ignore' => 404,
+                    ],
+                'body' => '{"query":{"query_string":{"default_operator":"AND","query":"(\\"item\\")"}},"sort":{"_id":{"order":"DESC"}}}',
+            ]
+        );
+    }
+}


### PR DESCRIPTION
As we do not plan to index some resources on the elastic search (Ex: Users, Roles), we need to provide the search on those resources to maintain compatibility on the components which use the search service.
The solution for this is to check if there is an index to the proper resource if yes, Elasticsearch will be used otherwise GenerisSearch will be used.