### PR TITLE
Feature/tao 10365 apply access control to queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG
 - Added a query builder to handle searches on different indexes
 - Updated indexes when custom properties are changed/deleted using IndexUpdater Interface.
 - Added DACL to indexation
+- Added User roles to the search query
 
 1.1.1
 -----

--- a/src/ElasticSearch.php
+++ b/src/ElasticSearch.php
@@ -62,7 +62,7 @@ class ElasticSearch extends ConfigurableService implements Search
     protected function getQueryBuilder(): QueryBuilder
     {
         if (is_null($this->queryBuilder)) {
-            $this->queryBuilder = QueryBuilder::create();
+            $this->queryBuilder = $this->getServiceLocator()->get(QueryBuilder::class);
         }
 
         return $this->queryBuilder;

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -21,6 +21,8 @@ declare(strict_types=1);
 
 namespace oat\tao\elasticsearch;
 
+use oat\generis\model\data\permission\PermissionInterface;
+use oat\generis\model\data\permission\ReverseRightLookupInterface;
 use oat\oatbox\service\ConfigurableService;
 use oat\oatbox\session\SessionService;
 use oat\oatbox\user\User;
@@ -72,7 +74,9 @@ class QueryBuilder extends ConfigurableService
             }
         }
 
-        $query[] = $this->buildAccessConditions();
+        if ($this->includeAccessData()) {
+            $query[] = $this->buildAccessConditions();
+        }
 
         $query = [
             'query' => [
@@ -137,5 +141,11 @@ class QueryBuilder extends ConfigurableService
         }
 
         return '(' . implode(' OR ', $conditions). ')';
+    }
+
+    private function includeAccessData(): bool {
+        $permissionProvider = $this->getServiceLocator()->get(PermissionInterface::SERVICE_ID);
+
+        return $permissionProvider instanceof ReverseRightLookupInterface;
     }
 }

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -143,7 +143,8 @@ class QueryBuilder extends ConfigurableService
         return '(' . implode(' OR ', $conditions). ')';
     }
 
-    private function includeAccessData(): bool {
+    private function includeAccessData(): bool
+    {
         $permissionProvider = $this->getServiceLocator()->get(PermissionInterface::SERVICE_ID);
 
         return $permissionProvider instanceof ReverseRightLookupInterface;

--- a/test/QueryBuilderTest.php
+++ b/test/QueryBuilderTest.php
@@ -32,7 +32,8 @@ class QueryBuilderTest extends TestCase
     /**
      * @dataProvider queryResults
      */
-    public function testGetSearchParams(string $queryString, string $body): void {
+    public function testGetSearchParams(string $queryString, string $body): void
+    {
         $expected = [
             'index' => 'items',
             'size' => 10,
@@ -48,7 +49,8 @@ class QueryBuilderTest extends TestCase
         $this->assertSame($expected, $result);
     }
 
-    public function queryResults() {
+    public function queryResults(): array
+    {
         return [
             [
                 'test',
@@ -95,7 +97,8 @@ class QueryBuilderTest extends TestCase
     /**
      * @dataProvider queryResultsWithAccessControl
      */
-    public function testGetSearchParamsWithAccessControl(string $queryString, string $body): void {
+    public function testGetSearchParamsWithAccessControl(string $queryString, string $body): void
+    {
         $this->createAccessControlMock();
 
         $expected = [
@@ -113,7 +116,8 @@ class QueryBuilderTest extends TestCase
         $this->assertSame($expected, $result);
     }
 
-    public function queryResultsWithAccessControl() {
+    public function queryResultsWithAccessControl() : array
+    {
         return [
             [
                 'test',

--- a/test/QueryBuilderTest.php
+++ b/test/QueryBuilderTest.php
@@ -6,6 +6,7 @@ use oat\generis\test\TestCase;
 use oat\tao\elasticsearch\IndexerInterface;
 use oat\tao\elasticsearch\QueryBuilder;
 use oat\tao\model\TaoOntology;
+use Zend\ServiceManager\ServiceLocatorInterface;
 
 class QueryBuilderTest extends TestCase
 {
@@ -14,7 +15,10 @@ class QueryBuilderTest extends TestCase
 
     protected function setUp(): void
     {
-       $this->subject = QueryBuilder::create();
+        $serviceLocator = $this->createMock(ServiceLocatorInterface::class);
+
+        $this->subject = QueryBuilder::create();
+        $this->subject->setServiceLocator($serviceLocator);
     }
 
     /**

--- a/test/QueryBuilderTest.php
+++ b/test/QueryBuilderTest.php
@@ -72,6 +72,14 @@ class QueryBuilderTest extends TestCase
             [
                 'label:test AND custom_field:test',
                 '{"query":{"query_string":{"default_operator":"AND","query":"(label:\"test\") AND (HTMLArea_custom-field:\"test\" OR TextArea_custom-field:\"test\" OR TextBox_custom-field:\"test\" OR ComboBox_custom-field:\"test\" OR CheckBox_custom-field:\"test\" OR RadioBox_custom-field:\"test\")"}},"sort":{"_id":{"order":"DESC"}}}',
+            ],
+            [
+                'label:test and custom_field:test',
+                '{"query":{"query_string":{"default_operator":"AND","query":"(label:\"test\") AND (HTMLArea_custom-field:\"test\" OR TextArea_custom-field:\"test\" OR TextBox_custom-field:\"test\" OR ComboBox_custom-field:\"test\" OR CheckBox_custom-field:\"test\" OR RadioBox_custom-field:\"test\")"}},"sort":{"_id":{"order":"DESC"}}}',
+            ],
+            [
+                'label:test aNd custom_field:test',
+                '{"query":{"query_string":{"default_operator":"AND","query":"(label:\"test\") AND (HTMLArea_custom-field:\"test\" OR TextArea_custom-field:\"test\" OR TextBox_custom-field:\"test\" OR ComboBox_custom-field:\"test\" OR CheckBox_custom-field:\"test\" OR RadioBox_custom-field:\"test\")"}},"sort":{"_id":{"order":"DESC"}}}',
             ]
         ];
     }

--- a/test/QueryBuilderTest.php
+++ b/test/QueryBuilderTest.php
@@ -2,7 +2,12 @@
 
 namespace oat\tao\test\elasticsearch;
 
+use oat\generis\model\data\permission\PermissionInterface;
+use oat\generis\model\data\permission\ReverseRightLookupInterface;
+use oat\generis\test\MockObject;
 use oat\generis\test\TestCase;
+use oat\oatbox\session\SessionService;
+use oat\oatbox\user\User;
 use oat\tao\elasticsearch\IndexerInterface;
 use oat\tao\elasticsearch\QueryBuilder;
 use oat\tao\model\TaoOntology;
@@ -13,12 +18,15 @@ class QueryBuilderTest extends TestCase
     /** @var QueryBuilder */
     private $subject;
 
+    /** @var ServiceLocatorInterface|MockObject  */
+    private $serviceLocator;
+
     protected function setUp(): void
     {
-        $serviceLocator = $this->createMock(ServiceLocatorInterface::class);
+        $this->serviceLocator = $this->createMock(ServiceLocatorInterface::class);
 
         $this->subject = QueryBuilder::create();
-        $this->subject->setServiceLocator($serviceLocator);
+        $this->subject->setServiceLocator($this->serviceLocator);
     }
 
     /**
@@ -82,5 +90,64 @@ class QueryBuilderTest extends TestCase
                 '{"query":{"query_string":{"default_operator":"AND","query":"(label:\"test\") AND (HTMLArea_custom-field:\"test\" OR TextArea_custom-field:\"test\" OR TextBox_custom-field:\"test\" OR ComboBox_custom-field:\"test\" OR CheckBox_custom-field:\"test\" OR RadioBox_custom-field:\"test\")"}},"sort":{"_id":{"order":"DESC"}}}',
             ]
         ];
+    }
+
+    /**
+     * @dataProvider queryResultsWithAccessControl
+     */
+    public function testGetSearchParamsWithAccessControl(string $queryString, string $body): void {
+        $this->createAccessControlMock();
+
+        $expected = [
+            'index' => 'items',
+            'size' => 10,
+            'from' => 0,
+            'client' => [
+                'ignore' => 404
+            ],
+            'body' => $body,
+        ];
+
+        $result = $this->subject->getSearchParams($queryString, TaoOntology::CLASS_URI_ITEM, 0, 10, '_id', 'DESC');
+
+        $this->assertSame($expected, $result);
+    }
+
+    public function queryResultsWithAccessControl() {
+        return [
+            [
+                'test',
+                '{"query":{"query_string":{"default_operator":"AND","query":"(\"test\") AND (read_access:\"http:\/\/www.tao.lu\/Ontologies\/TAOItem.rdf#BackOfficeRole\" OR read_access:\"http:\/\/www.tao.lu\/Ontologies\/TAOItem.rdf#ItemsManagerRole\")"}},"sort":{"_id":{"order":"DESC"}}}'
+
+            ],
+        ];
+    }
+
+    private function createAccessControlMock(): void
+    {
+        $permissionProvider = $this->createMock(ReverseRightLookupInterface::class);
+        $sessionService = $this->createMock(SessionService::class);
+        $user = $this->createMock(User::class);
+
+        $this->serviceLocator->expects($this->at(0))
+            ->method('get')
+            ->with(PermissionInterface::SERVICE_ID)
+            ->willReturn($permissionProvider);
+
+        $this->serviceLocator->expects($this->at(1))
+            ->method('get')
+            ->with(SessionService::SERVICE_ID)
+            ->willReturn($sessionService);
+
+        $sessionService->expects($this->once())
+            ->method('getCurrentUser')
+            ->willReturn($user);
+
+        $user->expects($this->once())
+            ->method('getRoles')
+            ->willReturn([
+                'http://www.tao.lu/Ontologies/TAOItem.rdf#BackOfficeRole',
+                'http://www.tao.lu/Ontologies/TAOItem.rdf#ItemsManagerRole'
+            ]);
     }
 }


### PR DESCRIPTION
With this PR, we are adding the list of roles the logged user have to the elastic search query, in order to only bring results that he have access to see.