### PR TITLE
Feature/tao 10378 indexation of assets resource

### DIFF
--- a/config/index.conf.php
+++ b/config/index.conf.php
@@ -286,4 +286,34 @@ return [
             ],
         ],
     ],
+    'assets' => [
+        'index' => 'assets',
+        'body' => [
+            'mappings' => [
+                'properties' => [
+                    'class' => [
+                        'type' => 'text',
+                    ],
+                    'label' => [
+                        'type' => 'text'
+                    ],
+                    'type' => [
+                        'type' => 'keyword',
+                        'ignore_above' => 256,
+                    ],
+                    'read_access' => [
+                        'type' => 'keyword',
+                        'ignore_above' => 256,
+                    ],
+                ],
+                'dynamic_templates' => $dynamicTemplates,
+            ],
+            'settings' => [
+                'index' => [
+                    'number_of_shards' => '1',
+                    'number_of_replicas' => '1',
+                ],
+            ],
+        ],
+    ],
 ];

--- a/src/ElasticSearch.php
+++ b/src/ElasticSearch.php
@@ -148,12 +148,9 @@ class ElasticSearch extends ConfigurableService implements Search
     {
         $indexes = $this->getOption('indexes');
 
-        $this->getClient()->indices()->create($indexes['items']);
-        $this->getClient()->indices()->create($indexes['tests']);
-        $this->getClient()->indices()->create($indexes['groups']);
-        $this->getClient()->indices()->create($indexes['deliveries']);
-        $this->getClient()->indices()->create($indexes['delivery-results']);
-        $this->getClient()->indices()->create($indexes['test-takers']);
+        foreach ($indexes as $index) {
+            $this->getClient()->indices()->create($index);
+        }
     }
 
     public function flush(): array

--- a/src/IndexerInterface.php
+++ b/src/IndexerInterface.php
@@ -38,6 +38,10 @@ interface IndexerInterface
     public const DELIVERY_RESULTS_INDEX = 'delivery-results';
     public const GROUPS_INDEX = 'groups';
     public const UNCLASSIFIEDS_DOCUMENTS_INDEX = 'unclassifieds';
+    public const ASSETS_INDEX = 'assets';
+
+    public const MEDIA_CLASS_URI = 'http://www.tao.lu/Ontologies/TAOMedia.rdf#Media';
+
     public const AVAILABLE_INDEXES = [
         ResultService::DELIVERY_RESULT_CLASS_URI => self::DELIVERY_RESULTS_INDEX,
         TaoOntology::CLASS_URI_ASSEMBLED_DELIVERY => self::DELIVERIES_INDEX,
@@ -47,6 +51,7 @@ interface IndexerInterface
         TaoOntology::CLASS_URI_RESULT => self::DELIVERIES_INDEX,
         TaoOntology::CLASS_URI_SUBJECT => self::TEST_TAKERS_INDEX,
         TaoOntology::CLASS_URI_TEST => self::TESTS_INDEX,
+        self::MEDIA_CLASS_URI => self::ASSETS_INDEX,
     ];
     public const INDEXES_WITH_ACCESS_CONTROL = [
         self::ITEMS_INDEX,


### PR DESCRIPTION
This implementation is intended to cover the ticket https://oat-sa.atlassian.net/browse/TAO-10378.

Before this implementation: 
- Clients can only find assets by label and URI

After this implementation: 
- Clients will be able to search by label, URI, class name, class URI, dynamic properties using specific fields or full-text search
- Search results will be displayed according to clients credentials 
