### PR TITLE
Feature/tao 10366 create event for changing resource privileges

### DIFF
--- a/src/IndexUpdater.php
+++ b/src/IndexUpdater.php
@@ -124,7 +124,7 @@ class IndexUpdater extends ConfigurableService implements IndexUpdaterInterface
                 sprintf(
                     'by script: %s AND type: %s',
                     $script,
-                    $type
+                    $typeOrId
                 ),
                 $e->getCode(),
                 $e

--- a/src/IndexUpdater.php
+++ b/src/IndexUpdater.php
@@ -62,7 +62,7 @@ class IndexUpdater extends ConfigurableService implements IndexUpdaterInterface
                 continue;
             }
 
-            $typeOrId = $propertyData['type'];
+            $type = $propertyData['type'];
             $parentClasses = $propertyData['parentClasses'];
 
             $queryNewProperty[] = sprintf(
@@ -76,11 +76,11 @@ class IndexUpdater extends ConfigurableService implements IndexUpdaterInterface
             );
         }
 
-        if (!isset($typeOrId, $parentClasses)) {
+        if (!isset($type, $parentClasses)) {
             return;
         }
 
-        $index = $this->findIndex($parentClasses, $typeOrId);
+        $index = $this->findIndex($parentClasses, $type);
 
         if ($index === IndexerInterface::UNCLASSIFIEDS_DOCUMENTS_INDEX) {
             return;
@@ -89,13 +89,13 @@ class IndexUpdater extends ConfigurableService implements IndexUpdaterInterface
         $script = implode(' ', array_merge($queryNewProperty, $queryRemoveOldProperty));
 
         try {
-            $this->executeUpdateQuery($index, $typeOrId, $script);
+            $this->executeUpdateQuery($index, $type, $script);
         } catch (Throwable $e) {
             throw new FailToUpdatePropertiesException(
                 sprintf(
                     'by script: %s AND type: %s',
                     $script,
-                    $typeOrId
+                    $type
                 ),
                 $e->getCode(),
                 $e
@@ -135,14 +135,14 @@ class IndexUpdater extends ConfigurableService implements IndexUpdaterInterface
     public function deleteProperty(array $property): void
     {
         $name = $property['name'];
-        $typeOrId = $property['type'];
+        $type = $property['type'];
         $parentClasses = $property['parentClasses'];
 
-        if (empty($name) || empty($typeOrId)) {
+        if (empty($name) || empty($type)) {
             return;
         }
 
-        $index = $this->findIndex($parentClasses, $typeOrId);
+        $index = $this->findIndex($parentClasses, $type);
 
         if ($index === IndexerInterface::UNCLASSIFIEDS_DOCUMENTS_INDEX) {
             return;
@@ -154,13 +154,13 @@ class IndexUpdater extends ConfigurableService implements IndexUpdaterInterface
         );
 
         try {
-            $this->executeUpdateQuery($index, $typeOrId, $script);
+            $this->executeUpdateQuery($index, $type, $script);
         } catch (Throwable $e) {
             throw new FailToRemovePropertyException(
                 sprintf(
                     'by script: %s AND type: %s',
                     $script,
-                    $typeOrId
+                    $type
                 ),
                 $e->getCode(),
                 $e
@@ -173,10 +173,10 @@ class IndexUpdater extends ConfigurableService implements IndexUpdaterInterface
         return isset(IndexerInterface::AVAILABLE_INDEXES[$class]);
     }
 
-    private function findIndex(array $parentClasses, string $typeOrId): string
+    private function findIndex(array $parentClasses, string $type): string
     {
-        if (isset(IndexerInterface::AVAILABLE_INDEXES[$typeOrId])) {
-            return IndexerInterface::AVAILABLE_INDEXES[$typeOrId];
+        if (isset(IndexerInterface::AVAILABLE_INDEXES[$type])) {
+            return IndexerInterface::AVAILABLE_INDEXES[$type];
         }
 
         foreach ($parentClasses as $parentClass) {

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -139,14 +139,19 @@ class QueryBuilder extends ConfigurableService
     {
         $conditions = [];
 
-        /** @var User $current_user */
-        $current_user = $this->getServiceLocator()->get(SessionService::SERVICE_ID)->getCurrentUser();
+        /** @var User $currentUser */
+        $currentUser = $this->getServiceLocator()->get(SessionService::SERVICE_ID)->getCurrentUser();
 
-        foreach ($current_user->getRoles() as $role) {
-            $conditions[] = sprintf('%s:"%s"', self::READ_ACCESS_FIELD, $role);
+        $conditions[] = $currentUser->getIdentifier();
+        foreach ($currentUser->getRoles() as $role) {
+            $conditions[] = $role;
         }
 
-        return '(' . implode(' OR ', $conditions). ')';
+        return sprintf(
+            '(%s:("%s"))',
+            self::READ_ACCESS_FIELD,
+            implode('" OR "', $conditions)
+        );
     }
 
     private function includeAccessData(string $index): bool

--- a/test/IndexUpdaterTest.php
+++ b/test/IndexUpdaterTest.php
@@ -73,9 +73,10 @@ class IndexUpdaterTest extends TestCase
                     'wait_for_completion' => true,
                     'body' => [
                         'query' => [
-                            'match' => [
-                                'type' => TaoOntology::CLASS_URI_ITEM
-                            ]
+                            'multi_match' => [
+                                'query' => TaoOntology::CLASS_URI_ITEM,
+                                'fields' => ['type', '_id'],
+                            ],
                         ],
                         'script' => [
                             'source' => $source
@@ -83,7 +84,7 @@ class IndexUpdaterTest extends TestCase
                     ]
                 ]
             );
-        $this->sut->updateProperties(
+        $this->sut->updatePropertiesName(
             $properties
         );
     }
@@ -95,7 +96,7 @@ class IndexUpdaterTest extends TestCase
             ->method('updateByQuery')
             ->willThrowException(new BadMethodCallException());
 
-        $this->sut->updateProperties(
+        $this->sut->updatePropertiesName(
             [
                 [
                     'newName' => 'test',
@@ -115,7 +116,7 @@ class IndexUpdaterTest extends TestCase
         $this->client->expects($this->never())
             ->method('updateByQuery');
 
-        $this->sut->updateProperties(
+        $this->sut->updatePropertiesName(
             $properties
         );
     }
@@ -135,9 +136,10 @@ class IndexUpdaterTest extends TestCase
                     'wait_for_completion' => true,
                     'body' => [
                         'query' => [
-                            'match' => [
-                                'type' => TaoOntology::CLASS_URI_ITEM
-                            ]
+                            'multi_match' => [
+                                'query' => TaoOntology::CLASS_URI_ITEM,
+                                'fields' => ['type', '_id'],
+                            ],
                         ],
                         'script' => [
                             'source' => $source

--- a/test/IndexUpdaterTest.php
+++ b/test/IndexUpdaterTest.php
@@ -178,6 +178,74 @@ class IndexUpdaterTest extends TestCase
         $this->sut->deleteProperty($property);
     }
 
+    public function testUpdatePropertyValueSuccessfuly()
+    {
+        $documentUri = 'https://tao.docker.localhost/ontologies/tao.rdf#i5ef45f413088c8e7901a84708e84ec';
+        $validType = 'http://www.tao.lu/Ontologies/TAOItem.rdf#Item';
+        $source = 'ctx._source[\'RadioBox_isTest\'] = [\'123456\'];';
+
+        $this->client->expects($this->once())
+            ->method('updateByQuery')
+            ->with(
+                [
+                    'index' => 'items',
+                    'type' => '_doc',
+                    'conflicts' => 'proceed',
+                    'wait_for_completion' => true,
+                    'body' => [
+                        'query' => [
+                            'multi_match' => [
+                                'query' => $documentUri,
+                                'fields' => ['type', '_id'],
+                            ],
+                        ],
+                        'script' => [
+                            'source' => $source
+                        ]
+                    ]
+                ]
+            );
+
+        $this->sut->updatePropertyValue(
+            $documentUri,
+            [
+                $validType
+            ],
+            'RadioBox_isTest',
+            ['123456']
+        );
+    }
+
+    public function testUpdatePropertyValueDoNothingInCaseUnclassifiedIndex()
+    {
+        $this->client->expects($this->never())
+            ->method('updateByQuery');
+
+        $invalidType = 'https://tao.docker.localhost/ontologies/tao.rdf#Invalid';
+
+        $this->sut->updatePropertyValue($invalidType, [], 'RadioBox_isTest', ['123456']);
+    }
+
+    public function testExceptionWhenUpdatingPropertyValue()
+    {
+        $this->expectException(FailToUpdatePropertiesException::class);
+
+        $this->client->expects($this->once())
+            ->method('updateByQuery')
+            ->willThrowException(new BadMethodCallException());
+        $documentUri = 'https://tao.docker.localhost/ontologies/tao.rdf#i5ef45f413088c8e7901a84708e84ec';
+        $validType = 'http://www.tao.lu/Ontologies/TAOItem.rdf#Item';
+
+        $this->sut->updatePropertyValue(
+            $documentUri,
+            [
+                $validType
+            ],
+            'RadioBox_isTest',
+            ['123456']
+        );
+    }
+
     public function provideValidPropertiesForUpdate(): array
     {
         return [

--- a/test/QueryBuilderTest.php
+++ b/test/QueryBuilderTest.php
@@ -148,7 +148,7 @@ class QueryBuilderTest extends TestCase
         return [
             [
                 'test',
-                '{"query":{"query_string":{"default_operator":"AND","query":"(\"test\") AND (read_access:\"http:\/\/www.tao.lu\/Ontologies\/TAOItem.rdf#BackOfficeRole\" OR read_access:\"http:\/\/www.tao.lu\/Ontologies\/TAOItem.rdf#ItemsManagerRole\")"}},"sort":{"_id":{"order":"DESC"}}}'
+                '{"query":{"query_string":{"default_operator":"AND","query":"(\"test\") AND (read_access:(\"https:\/\/tao.docker.localhost\/ontologies\/tao.rdf#i5f64514f1c36110793759fc28c0105b\" OR \"http:\/\/www.tao.lu\/Ontologies\/TAOItem.rdf#BackOfficeRole\" OR \"http:\/\/www.tao.lu\/Ontologies\/TAOItem.rdf#ItemsManagerRole\"))"}},"sort":{"_id":{"order":"DESC"}}}'
 
             ],
         ];
@@ -159,6 +159,9 @@ class QueryBuilderTest extends TestCase
         $permissionProvider = $this->createMock(ReverseRightLookupInterface::class);
         $sessionService = $this->createMock(SessionService::class);
         $user = $this->createMock(User::class);
+        $user->expects($this->once())->method('getIdentifier')->willReturn(
+            'https://tao.docker.localhost/ontologies/tao.rdf#i5f64514f1c36110793759fc28c0105b'
+        );
 
         $this->serviceLocator->expects($this->at(0))
             ->method('get')

--- a/test/QueryBuilderTest.php
+++ b/test/QueryBuilderTest.php
@@ -146,7 +146,7 @@ class QueryBuilderTest extends TestCase
     public function queryResultsWithAccessControl() : array
     {
         return [
-            [
+           'with user access control and role access control' => [
                 'test',
                 '{"query":{"query_string":{"default_operator":"AND","query":"(\"test\") AND (read_access:(\"https:\/\/tao.docker.localhost\/ontologies\/tao.rdf#i5f64514f1c36110793759fc28c0105b\" OR \"http:\/\/www.tao.lu\/Ontologies\/TAOItem.rdf#BackOfficeRole\" OR \"http:\/\/www.tao.lu\/Ontologies\/TAOItem.rdf#ItemsManagerRole\"))"}},"sort":{"_id":{"order":"DESC"}}}'
 


### PR DESCRIPTION
This PR is intended to implement the issue https://oat-sa.atlassian.net/browse/TAO-10366
Please also take a look at the PRs:
- https://github.com/oat-sa/tao-core/pull/2684
- https://github.com/oat-sa/extension-tao-dac-simple/pull/149

**The issue:** 

When the user updates Data Access Control on the resource, these changes are not reflected in the advanced search.

**The solution:** 
A new event was created (DataAccessControlChangedEvent) to be possible to have Advanced search up to date

**Extra fixes**
- 500 error on search action (actions/class.Search.php) when trying to filter permissions on empty results (https://github.com/oat-sa/tao-core/pull/2684).
- Fail during search resources that have access control by the user instead of by role. We need to include the user identifier on the query to get a proper result.
- fixed wrong interface implementation IndexSinceLastRunService:runIndexing method (https://github.com/oat-sa/tao-core/pull/2684). 