### PR TITLE
Added more generic search method decoupled from TAO

### DIFF
--- a/src/ElasticSearch.php
+++ b/src/ElasticSearch.php
@@ -120,7 +120,7 @@ class ElasticSearch extends ConfigurableService implements Search, SearchInterfa
 
         try {
             $query = $this->getQueryBuilder()->getSearchParams($queryString, $type, $start, $count, $order, $dir);
-            $this->getLogger()->critical('Query ' . var_export($query, true), $query);
+            $this->getLogger()->debug('Query ', $query);
 
             return $this->buildResultSet(
                 $this->getClient()->search(

--- a/src/ElasticSearch.php
+++ b/src/ElasticSearch.php
@@ -53,13 +53,13 @@ class ElasticSearch extends ConfigurableService implements Search, SearchInterfa
                 [
                     'query' => [
                         'query_string' => [
-                            "default_operator" => "AND",
-                            "query" => $query->getQueryString()
+                            'default_operator' => 'AND',
+                            'query' => $query->getQueryString()
                         ]
                     ],
-                    "size" => $query->getLimit(),
-                    "from" => $query->getOffset(),
-                    "sort" => [],
+                    'size' => $query->getLimit(),
+                    'from' => $query->getOffset(),
+                    'sort' => [],
                 ]
             )
         ];

--- a/src/ElasticSearch.php
+++ b/src/ElasticSearch.php
@@ -14,7 +14,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2018 (original work) Open Assessment Technologies SA;
+ * Copyright (c) 2018-2021 (original work) Open Assessment Technologies SA;
  */
 
 declare(strict_types=1);

--- a/src/Query.php
+++ b/src/Query.php
@@ -14,7 +14,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2020 (original work) Open Assessment Technologies SA;
+ * Copyright (c) 2020-2021 (original work) Open Assessment Technologies SA;
  *
  */
 

--- a/src/Query.php
+++ b/src/Query.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA;
+ *
+ */
+
+declare(strict_types=1);
+
+namespace oat\tao\elasticsearch;
+
+class Query
+{
+    /** @var string */
+    private $index;
+
+    /** @var int */
+    private $limit;
+
+    /** @var int */
+    private $offset;
+
+    /** @var array */
+    private $conditions;
+
+    public function __construct(string $index)
+    {
+        $this->index = $index;
+        $this->offset = 0;
+        $this->limit = 1000;
+        $this->conditions = [];
+    }
+
+    public function getIndex(): string
+    {
+        return $this->index;
+    }
+
+    public function getLimit(): int
+    {
+        return $this->limit;
+    }
+
+    public function setLimit(int $limit): self
+    {
+        $this->limit = $limit;
+
+        return $this;
+    }
+
+    public function getOffset(): int
+    {
+        return $this->offset;
+    }
+
+    public function setOffset(int $offset): self
+    {
+        $this->offset = $offset;
+
+        return $this;
+    }
+
+    public function getQueryString(): string
+    {
+        return implode('AND ', $this->conditions);
+    }
+
+    public function addCondition(string $condition): self
+    {
+        $this->conditions[] = $condition;
+        
+        return $this;
+    }
+}

--- a/src/Query.php
+++ b/src/Query.php
@@ -24,6 +24,8 @@ namespace oat\tao\elasticsearch;
 
 class Query
 {
+    private const LIMIT_DEFAULT = 1000;
+
     /** @var string */
     private $index;
 
@@ -40,7 +42,7 @@ class Query
     {
         $this->index = $index;
         $this->offset = 0;
-        $this->limit = 1000;
+        $this->limit = self::LIMIT_DEFAULT;
         $this->conditions = [];
     }
 
@@ -81,7 +83,7 @@ class Query
     public function addCondition(string $condition): self
     {
         $this->conditions[] = $condition;
-        
+
         return $this;
     }
 }

--- a/src/SearchInterface.php
+++ b/src/SearchInterface.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\tao\elasticsearch;
+
+interface SearchInterface
+{
+    public function search(Query $query): SearchResult;
+}

--- a/src/SearchResult.php
+++ b/src/SearchResult.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\tao\elasticsearch;
+
+use oat\tao\model\search\ResultSet;
+
+class SearchResult extends ResultSet
+{
+}

--- a/test/ElasticSearchTest.php
+++ b/test/ElasticSearchTest.php
@@ -28,7 +28,9 @@ use oat\generis\test\TestCase;
 use oat\oatbox\log\LoggerService;
 use oat\tao\elasticsearch\ElasticSearch;
 use oat\tao\elasticsearch\IndexUpdater;
+use oat\tao\elasticsearch\Query;
 use oat\tao\elasticsearch\QueryBuilder;
+use oat\tao\elasticsearch\SearchResult;
 use oat\tao\model\search\ResultSet;
 use oat\tao\model\search\strategy\GenerisSearch;
 use oat\tao\model\search\SyntaxException;
@@ -114,6 +116,38 @@ class ElasticSearchTest extends TestCase
             $this->sut,
             $this->client
         );
+    }
+
+    public function testSearch(): void
+    {
+        $query = [
+            'index' => 'indexName',
+            'body' => json_encode(
+                [
+                    'query' => [
+                        'query_string' => [
+                            "default_operator" => "AND",
+                            "query" => 'a:"b"'
+                        ]
+                    ],
+                    "size" => 777,
+                    "from" => 7,
+                    "sort" => [],
+                ]
+            )
+        ];
+        
+        $this->client
+            ->method('search')
+            ->with($query)
+            ->willReturn([]);
+
+        $query = (new Query('indexName'))
+            ->setOffset(7)
+            ->setLimit(777)
+            ->addCondition('a:"b"');
+
+        $this->assertEquals(new SearchResult([], 0), $this->sut->search($query));
     }
 
     public function testQuery_callGenerisSearchCaseClassIsNotSupported(): void

--- a/test/ElasticSearchTest.php
+++ b/test/ElasticSearchTest.php
@@ -126,13 +126,13 @@ class ElasticSearchTest extends TestCase
                 [
                     'query' => [
                         'query_string' => [
-                            "default_operator" => "AND",
-                            "query" => 'a:"b"'
+                            'default_operator' => 'AND',
+                            'query' => 'a:"b"'
                         ]
                     ],
-                    "size" => 777,
-                    "from" => 7,
-                    "sort" => [],
+                    'size' => 777,
+                    'from' => 7,
+                    'sort' => [],
                 ]
             )
         ];

--- a/test/QueryTest.php
+++ b/test/QueryTest.php
@@ -30,14 +30,14 @@ class QueryTest extends TestCase
 {
     public function testGetters(): void
     {
-        $queryBlock = (new Query('indexName'))
+        $query = (new Query('indexName'))
             ->setOffset(7)
             ->setLimit(777)
             ->addCondition('a:"b"');
 
-        $this->assertSame('indexName', $queryBlock->getIndex());
-        $this->assertSame(7, $queryBlock->getOffset());
-        $this->assertSame(777, $queryBlock->getLimit());
-        $this->assertSame('a:"b"', $queryBlock->getQueryString());
+        $this->assertSame('indexName', $query->getIndex());
+        $this->assertSame(7, $query->getOffset());
+        $this->assertSame(777, $query->getLimit());
+        $this->assertSame('a:"b"', $query->getQueryString());
     }
 }

--- a/test/QueryTest.php
+++ b/test/QueryTest.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA;
+ *
+ */
+
+declare(strict_types=1);
+
+namespace oat\tao\test\elasticsearch;
+
+use oat\generis\test\TestCase;
+use oat\tao\elasticsearch\Query;
+use oat\tao\elasticsearch\QueryBlock;
+
+class QueryTest extends TestCase
+{
+    public function testGetters(): void
+    {
+        $queryBlock = (new Query('indexName'))
+            ->setOffset(7)
+            ->setLimit(777)
+            ->addCondition('a:"b"');
+
+        $this->assertSame('indexName', $queryBlock->getIndex());
+        $this->assertSame(7, $queryBlock->getOffset());
+        $this->assertSame(777, $queryBlock->getLimit());
+        $this->assertSame('a:"b"', $queryBlock->getQueryString());
+    }
+}


### PR DESCRIPTION
Added more generic search method decoupled from TAO required to do specific searches

Related PRs:

- [ ] https://github.com/oat-sa/lib-tao-elasticsearch/pull/43
- [ ] https://github.com/oat-sa/tao-core/pull/2790
- [ ] https://github.com/oat-sa/extension-tao-advanced-search/pull/4

https://oat-sa.atlassian.net/browse/CON-497