### PR TITLE
fix: add count method

### DIFF
--- a/src/ElasticSearch.php
+++ b/src/ElasticSearch.php
@@ -44,6 +44,17 @@ class ElasticSearch extends ConfigurableService implements SearchInterface, TaoS
     /** @var QueryBuilder */
     private $queryBuilder;
 
+    public function countDocuments(string $index): int
+    {
+        $result = $this->getClient()->count(
+            [
+                'index' => $index
+            ]
+        );
+
+        return $result['count'] ?? 0;
+    }
+
     public function search(Query $query): SearchResult
     {
         $query = [

--- a/test/ElasticSearchTest.php
+++ b/test/ElasticSearchTest.php
@@ -150,6 +150,24 @@ class ElasticSearchTest extends TestCase
         $this->assertEquals(new SearchResult([], 0), $this->sut->search($query));
     }
     
+    public function testCountDocuments(): void
+    {
+        $this->client
+            ->method('count')
+            ->with(
+                [
+                    'index' => 'indexName',
+                ]
+            )
+            ->willReturn(
+                [
+                    'count' => 777,
+                ]
+            );
+
+        $this->assertEquals(777, $this->sut->countDocuments('indexName'));
+    }
+    
     public function testQuery_callElasticSearchCaseClassIsSupported(): void
     {
         $validType = 'http://www.tao.lu/Ontologies/TAOItem.rdf#Item';


### PR DESCRIPTION
If we do not use count endpoint, ElasticSearch can only count until 10000

- [ ] https://github.com/oat-sa/extension-tao-advanced-search/pull/45