### PR TITLE
fix: add ACL support for querybuilder

### DIFF
--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -74,6 +74,16 @@ class QueryBuilder extends ConfigurableService
         'SearchDropdown',
     ];
 
+    /** @var UseAclSpecification */
+    private $useAclSpecification;
+
+    public function withUseAclSpecification(UseAclSpecification $useAclSpecification): self
+    {
+        $this->useAclSpecification = $useAclSpecification;
+
+        return $this;
+    }
+
     public static function create(): self
     {
         return new self();
@@ -86,7 +96,7 @@ class QueryBuilder extends ConfigurableService
         $blocks = preg_split( '/( AND )/i', $queryString);
         $index = $this->getIndexByType($type);
         $conditions = $this->buildConditions($index, $blocks);
-
+        
         $query = [
             'query' => [
                 'query_string' =>
@@ -212,7 +222,7 @@ class QueryBuilder extends ConfigurableService
 
     private function includeAccessData(string $index): bool
     {
-        return (new UseAclSpecification())->isSatisfiedBy(
+        return $this->getUseAclSpecification()->isSatisfiedBy(
             $index,
             $this->getPermissionProvider(),
             $this->getSessionService()->getCurrentUser()
@@ -234,6 +244,15 @@ class QueryBuilder extends ConfigurableService
         }
 
         return new QueryBlock($field, trim($matches['term']));
+    }
+
+    private function getUseAclSpecification(): UseAclSpecification
+    {
+        if (!isset($this->useAclSpecification)) {
+            $this->useAclSpecification = new UseAclSpecification();
+        }
+
+        return $this->useAclSpecification;
     }
 
     private function isUri(string $term): bool

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -27,7 +27,6 @@ use oat\oatbox\service\ConfigurableService;
 use oat\oatbox\session\SessionService;
 use oat\oatbox\user\User;
 use oat\tao\model\user\TaoRoles;
-use oat\taoDacSimple\model\PermissionProvider;
 use tao_helpers_Uri;
 use common_Utils;
 

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -116,7 +116,7 @@ class QueryBuilder extends ConfigurableService
         $conditions = $this->buildConditionsByType($index, $blocks);
 
         if ($this->includeAccessData($index)) {
-            $conditions[] = $accessConditions;
+            $conditions[] = $this->buildAccessConditions();
         }
 
         return $conditions;

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -26,7 +26,7 @@ use oat\generis\model\data\permission\ReverseRightLookupInterface;
 use oat\oatbox\service\ConfigurableService;
 use oat\oatbox\session\SessionService;
 use oat\oatbox\user\User;
-use oat\tao\model\user\TaoRoles;
+use oat\tao\elasticsearch\Specification\UseAclSpecification;
 use tao_helpers_Uri;
 use common_Utils;
 

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -14,7 +15,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2020-2021 (original work) Open Assessment Technologies SA;
+ * Copyright (c) 2020-2022 (original work) Open Assessment Technologies SA;
  */
 
 declare(strict_types=1);
@@ -191,7 +192,7 @@ class QueryBuilder extends ConfigurableService
         return '(' . implode(' OR ', $conditions). ')';
     }
 
-    private function buildAccessConditions(): ?string
+    private function buildAccessConditions(): string
     {
         $conditions = [];
 

--- a/src/Specification/UseAclSpecification.php
+++ b/src/Specification/UseAclSpecification.php
@@ -33,10 +33,10 @@ class UseAclSpecification
     {
         return in_array($index, IndexerInterface::INDEXES_WITH_ACCESS_CONTROL, true)
             && $permission instanceof ReverseRightLookupInterface
-            && !$this->hasFullAccess($permission, $user);
+            && !$this->hasReadAccess($permission, $user);
     }
 
-    private function hasFullAccess(PermissionInterface $permission, User $user): bool
+    private function hasReadAccess(PermissionInterface $permission, User $user): bool
     {
         $nonExistingId = uniqid();
         $permissions = $permission->getPermissions($user, [$nonExistingId])[$nonExistingId] ?? [];

--- a/src/Specification/UseAclSpecification.php
+++ b/src/Specification/UseAclSpecification.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2022 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\tao\elasticsearch\Specification;
+
+use oat\generis\model\data\permission\PermissionInterface;
+use oat\generis\model\data\permission\ReverseRightLookupInterface;
+use oat\oatbox\user\User;
+
+class UseAclSpecification
+{
+    public function isSatisfiedBy(string $index, PermissionInterface $permission, User $user): bool
+    {
+        return in_array($index, IndexerInterface::INDEXES_WITH_ACCESS_CONTROL, true)
+            && $permission instanceof ReverseRightLookupInterface
+            && !$this->hasFullAccess($permission);
+    }
+
+    private function hasFullAccess(PermissionInterface $permission): bool
+    {
+        $nonExistingId = uniqid();
+        $permissions = $permission->getPermissions($user, [$nonExistingId])[$nonExistingId] ?? [];
+
+        return in_array(PermissionInterface::RIGHT_READ, $permissions, true);
+    }
+}

--- a/src/Specification/UseAclSpecification.php
+++ b/src/Specification/UseAclSpecification.php
@@ -25,6 +25,7 @@ namespace oat\tao\elasticsearch\Specification;
 use oat\generis\model\data\permission\PermissionInterface;
 use oat\generis\model\data\permission\ReverseRightLookupInterface;
 use oat\oatbox\user\User;
+use oat\tao\elasticsearch\IndexerInterface;
 
 class UseAclSpecification
 {
@@ -32,10 +33,10 @@ class UseAclSpecification
     {
         return in_array($index, IndexerInterface::INDEXES_WITH_ACCESS_CONTROL, true)
             && $permission instanceof ReverseRightLookupInterface
-            && !$this->hasFullAccess($permission);
+            && !$this->hasFullAccess($permission, $user);
     }
 
-    private function hasFullAccess(PermissionInterface $permission): bool
+    private function hasFullAccess(PermissionInterface $permission, User $user): bool
     {
         $nonExistingId = uniqid();
         $permissions = $permission->getPermissions($user, [$nonExistingId])[$nonExistingId] ?? [];

--- a/test/QueryBuilderTest.php
+++ b/test/QueryBuilderTest.php
@@ -30,8 +30,12 @@ use oat\oatbox\session\SessionService;
 use oat\oatbox\user\User;
 use oat\tao\elasticsearch\IndexerInterface;
 use oat\tao\elasticsearch\QueryBuilder;
+use oat\tao\elasticsearch\Specification\UseAclSpecification;
 use oat\tao\model\TaoOntology;
 use Zend\ServiceManager\ServiceLocatorInterface;
+
+interface PermissionMock extends PermissionInterface, ReverseRightLookupInterface {
+}
 
 class QueryBuilderTest extends TestCase
 {
@@ -50,14 +54,19 @@ class QueryBuilderTest extends TestCase
     /** @var LoggerService|MockObject */
     private $loggerService;
 
+    /** @var LoggerService|MockObject */
+    private $useAclSpecification;
+
     protected function setUp(): void
     {
         $this->sessionServiceMock = $this->createMock(SessionService::class);
-        $this->permissionMock = $this->createMock(ReverseRightLookupInterface::class);
+        $this->permissionMock = $this->createMock(PermissionMock::class);
         $this->loggerService = $this->createMock(LoggerService::class);
         $this->user = $this->createMock(User::class);
+        $this->useAclSpecification = $this->createMock(UseAclSpecification::class);
 
         $this->subject = new QueryBuilder();
+        $this->subject->withUseAclSpecification($this->useAclSpecification);
         $this->subject->setServiceLocator(
             $this->getServiceLocatorMock(
                 [
@@ -67,75 +76,41 @@ class QueryBuilderTest extends TestCase
                 ]
             )
         );
-    }
 
-    /**
-     * @dataProvider queryResults
-     */
-    public function testGetSearchParams(string $queryString, string $body): void
-    {
-        $this->createAccessControlMock();
-
-        $expected = [
-            'index' => 'items',
-            'size' => 10,
-            'from' => 0,
-            'client' => [
-                'ignore' => 404
-            ],
-            'body' => $body,
-        ];
-
-        $result = $this->subject->getSearchParams($queryString, IndexerInterface::ITEMS_INDEX, 0, 10, '_id', 'DESC');
-
-        $this->assertSame($expected, $result);
-    }
-
-    /**
-     * @dataProvider getTypeAndResultQuerie
-     */
-    public function testGetSearchParamsResultsIndex(string $query, string $type, string $resultingQuery)
-    {
         $this->sessionServiceMock
+            ->expects($this->any())
             ->method('getCurrentUser')
             ->willReturn($this->user);
-
-        $this->user
-            ->method('getRoles')
-            ->willReturn([
-                'role'
-            ]);
-
-        $result = $this->subject
-            ->getSearchParams($query, $type, 0, 10, '_id', 'DESC');
-
-        $this->assertEquals($resultingQuery, $result['body']);
     }
 
-    public function getTypeAndResultQuerie()
+    /**
+     * @dataProvider queryResultsWithAccessControl
+     */
+    public function testGetSearchParamsWithAccessControl(string $queryString, string $body): void
     {
-        return [
-            'Assembled Delivery Type' => [
-                'query_string',
-                IndexerInterface::DELIVERIES_INDEX,
-                '{"query":{"query_string":{"default_operator":"AND","query":"(\"query_string\")"}},"sort":{"_id":{"order":"DESC"}}}'
+        $this->createAccessControlMock(true);
+
+        $this->assertSame(
+            [
+                'index' => 'items',
+                'size' => 10,
+                'from' => 0,
+                'client' => [
+                    'ignore' => 404
+                ],
+                'body' => $body,
             ],
-            'Item Type' => [
-                'query_string AND parent_classes: "http://www.tao.lu/Ontologies/TAODelivery.rdf#AssembledDelivery"',
-                IndexerInterface::ITEMS_INDEX,
-                '{"query":{"query_string":{"default_operator":"AND","query":"(\"query_string\") AND (parent_classes:\"http:\/\/www.tao.lu\/Ontologies\/TAODelivery.rdf#AssembledDelivery\") AND (read_access:(\"\" OR \"role\"))"}},"sort":{"_id":{"order":"DESC"}}}'
-            ],
-            'Item Type Parent Class' => [
-                'query_string AND parent_classes: "http://www.tao.lu/Ontologies/TAODelivery.rdf#AssembledDelivery"',
-                IndexerInterface::DELIVERIES_INDEX,
-                '{"query":{"query_string":{"default_operator":"AND","query":"(\"query_string\") AND (parent_classes:\"http:\/\/www.tao.lu\/Ontologies\/TAODelivery.rdf#AssembledDelivery\")"}},"sort":{"_id":{"order":"DESC"}}}'
-            ],
-        ];
+            $this->subject->getSearchParams($queryString, IndexerInterface::ITEMS_INDEX, 0, 10, '_id', 'DESC')
+        );
     }
 
-    public function queryResults(): array
+    public function queryResultsWithAccessControl(): array
     {
         return [
+            'with user access control and role access control' => [
+                'test',
+                '{"query":{"query_string":{"default_operator":"AND","query":"(\"test\") AND (read_access:(\"https:\/\/tao.docker.localhost\/ontologies\/tao.rdf#i5f64514f1c36110793759fc28c0105b\" OR \"http:\/\/www.tao.lu\/Ontologies\/TAOItem.rdf#BackOfficeRole\" OR \"http:\/\/www.tao.lu\/Ontologies\/TAOItem.rdf#ItemsManagerRole\"))"}},"sort":{"_id":{"order":"DESC"}}}'
+            ],
             'Simple query' => [
                 'test',
                 '{"query":{"query_string":{"default_operator":"AND","query":"(\"test\") AND (read_access:(\"https:\/\/tao.docker.localhost\/ontologies\/tao.rdf#i5f64514f1c36110793759fc28c0105b\" OR \"http:\/\/www.tao.lu\/Ontologies\/TAOItem.rdf#BackOfficeRole\" OR \"http:\/\/www.tao.lu\/Ontologies\/TAOItem.rdf#ItemsManagerRole\"))"}},"sort":{"_id":{"order":"DESC"}}}'
@@ -184,55 +159,99 @@ class QueryBuilderTest extends TestCase
             ],
         ];
     }
-
+    
     /**
-     * @dataProvider queryResultsWithAccessControl
+     * @dataProvider queryResultsWithoutAccessControl
      */
-    public function testGetSearchParamsWithAccessControl(string $queryString, string $body): void
+    public function testGetSearchParamsWithoutAccessControl(string $queryString, string $body): void
     {
-        $this->createAccessControlMock();
+        $this->createAccessControlMock(false);
 
-        $expected = [
-            'index' => 'items',
-            'size' => 10,
-            'from' => 0,
-            'client' => [
-                'ignore' => 404
+        $this->assertSame(
+            [
+                'index' => 'items',
+                'size' => 10,
+                'from' => 0,
+                'client' => [
+                    'ignore' => 404
+                ],
+                'body' => $body,
             ],
-            'body' => $body,
-        ];
-
-        $result = $this->subject->getSearchParams($queryString, IndexerInterface::ITEMS_INDEX, 0, 10, '_id', 'DESC');
-
-        $this->assertSame($expected, $result);
+            $this->subject->getSearchParams($queryString, IndexerInterface::ITEMS_INDEX, 0, 10, '_id', 'DESC')
+        );
     }
 
-    public function queryResultsWithAccessControl(): array
+    public function queryResultsWithoutAccessControl(): array
     {
         return [
-            'with user access control and role access control' => [
+            'Simple query' => [
                 'test',
-                '{"query":{"query_string":{"default_operator":"AND","query":"(\"test\") AND (read_access:(\"https:\/\/tao.docker.localhost\/ontologies\/tao.rdf#i5f64514f1c36110793759fc28c0105b\" OR \"http:\/\/www.tao.lu\/Ontologies\/TAOItem.rdf#BackOfficeRole\" OR \"http:\/\/www.tao.lu\/Ontologies\/TAOItem.rdf#ItemsManagerRole\"))"}},"sort":{"_id":{"order":"DESC"}}}'
+                '{"query":{"query_string":{"default_operator":"AND","query":"(\"test\")"}},"sort":{"_id":{"order":"DESC"}}}'
+            ],
+            'Query specific field' => [
+                'label:test',
+                '{"query":{"query_string":{"default_operator":"AND","query":"(label:\"test\")"}},"sort":{"_id":{"order":"DESC"}}}'
 
+            ],
+            'Query specific field (variating case)' => [
+                'LaBeL:test',
+                '{"query":{"query_string":{"default_operator":"AND","query":"(label:\"test\")"}},"sort":{"_id":{"order":"DESC"}}}'
+
+            ],
+            'Query custom field (using underscore)' => [
+                'custom_field:test',
+                'body' => '{"query":{"query_string":{"default_operator":"AND","query":"(HTMLArea_custom_field:\"test\" OR TextArea_custom_field:\"test\" OR TextBox_custom_field:\"test\" OR ComboBox_custom_field:\"test\" OR CheckBox_custom_field:\"test\" OR RadioBox_custom_field:\"test\" OR SearchTextBox_custom_field:\"test\" OR SearchDropdown_custom_field:\"test\")"}},"sort":{"_id":{"order":"DESC"}}}',
+            ],
+            'Query custom field (using dash)' => [
+                'custom_field:test',
+                'body' => '{"query":{"query_string":{"default_operator":"AND","query":"(HTMLArea_custom_field:\"test\" OR TextArea_custom_field:\"test\" OR TextBox_custom_field:\"test\" OR ComboBox_custom_field:\"test\" OR CheckBox_custom_field:\"test\" OR RadioBox_custom_field:\"test\" OR SearchTextBox_custom_field:\"test\" OR SearchDropdown_custom_field:\"test\")"}},"sort":{"_id":{"order":"DESC"}}}',
+            ],
+            'Query custom field (using space)' => [
+                'custom field:test',
+                'body' => '{"query":{"query_string":{"default_operator":"AND","query":"(HTMLArea_custom field:\"test\" OR TextArea_custom field:\"test\" OR TextBox_custom field:\"test\" OR ComboBox_custom field:\"test\" OR CheckBox_custom field:\"test\" OR RadioBox_custom field:\"test\" OR SearchTextBox_custom field:\"test\" OR SearchDropdown_custom field:\"test\")"}},"sort":{"_id":{"order":"DESC"}}}',
+            ],
+            'Query logic operator (Uppercase)' => [
+                'label:test AND custom_field:test',
+                '{"query":{"query_string":{"default_operator":"AND","query":"(label:\"test\") AND (HTMLArea_custom_field:\"test\" OR TextArea_custom_field:\"test\" OR TextBox_custom_field:\"test\" OR ComboBox_custom_field:\"test\" OR CheckBox_custom_field:\"test\" OR RadioBox_custom_field:\"test\" OR SearchTextBox_custom_field:\"test\" OR SearchDropdown_custom_field:\"test\")"}},"sort":{"_id":{"order":"DESC"}}}',
+            ],
+            'Query logic operator (Lowercase)' => [
+                'label:test and custom_field:test',
+                '{"query":{"query_string":{"default_operator":"AND","query":"(label:\"test\") AND (HTMLArea_custom_field:\"test\" OR TextArea_custom_field:\"test\" OR TextBox_custom_field:\"test\" OR ComboBox_custom_field:\"test\" OR CheckBox_custom_field:\"test\" OR RadioBox_custom_field:\"test\" OR SearchTextBox_custom_field:\"test\" OR SearchDropdown_custom_field:\"test\")"}},"sort":{"_id":{"order":"DESC"}}}',
+            ],
+            'Query logic operator (Mixed)' => [
+                'label:test aNd custom_field:test',
+                '{"query":{"query_string":{"default_operator":"AND","query":"(label:\"test\") AND (HTMLArea_custom_field:\"test\" OR TextArea_custom_field:\"test\" OR TextBox_custom_field:\"test\" OR ComboBox_custom_field:\"test\" OR CheckBox_custom_field:\"test\" OR RadioBox_custom_field:\"test\" OR SearchTextBox_custom_field:\"test\" OR SearchDropdown_custom_field:\"test\")"}},"sort":{"_id":{"order":"DESC"}}}',
+            ],
+            'Query URIs' => [
+                'https://test-act.docker.localhost/ontologies/tao.rdf#i5f200ed20e80a8c259ebe410db7f6a',
+                '{"query":{"query_string":{"default_operator":"AND","query":"(\"https:\/\/test-act.docker.localhost\/ontologies\/tao.rdf#i5f200ed20e80a8c259ebe410db7f6a\")"}},"sort":{"_id":{"order":"DESC"}}}'
+            ],
+            'Query Field with URI' => [
+                'delivery: https://test-act.docker.localhost/ontologies/tao.rdf#i5f200ed20e80a8c259ebe410db7f6a',
+                '{"query":{"query_string":{"default_operator":"AND","query":"(delivery:\"https:\/\/test-act.docker.localhost\/ontologies\/tao.rdf#i5f200ed20e80a8c259ebe410db7f6a\")"}},"sort":{"_id":{"order":"DESC"}}}'
             ],
         ];
     }
 
-    private function createAccessControlMock(): void
+    private function createAccessControlMock(bool $includeAccessControl): void
     {
-        $this->user->expects($this->once())->method('getIdentifier')->willReturn(
-            'https://tao.docker.localhost/ontologies/tao.rdf#i5f64514f1c36110793759fc28c0105b'
-        );
+        $this->useAclSpecification
+            ->method('isSatisfiedBy')
+            ->willReturn($includeAccessControl);
 
-        $this->sessionServiceMock->expects($this->once())
-            ->method('getCurrentUser')
-            ->willReturn($this->user);
+        $this->user
+            ->expects($this->any())
+            ->method('getIdentifier')
+            ->willReturn('https://tao.docker.localhost/ontologies/tao.rdf#i5f64514f1c36110793759fc28c0105b');
 
-        $this->user->expects($this->once())
+        $this->user
+            ->expects($this->any())
             ->method('getRoles')
-            ->willReturn([
-                'http://www.tao.lu/Ontologies/TAOItem.rdf#BackOfficeRole',
-                'http://www.tao.lu/Ontologies/TAOItem.rdf#ItemsManagerRole'
-            ]);
+            ->willReturn(
+                [
+                    'http://www.tao.lu/Ontologies/TAOItem.rdf#BackOfficeRole',
+                    'http://www.tao.lu/Ontologies/TAOItem.rdf#ItemsManagerRole'
+                ]
+            );
     }
 }

--- a/test/Specification/UseAclSpecificationTest.php
+++ b/test/Specification/UseAclSpecificationTest.php
@@ -1,0 +1,124 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2022 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\tao\test\elasticsearch\Specification;
+
+use oat\generis\model\data\permission\PermissionInterface;
+use oat\generis\model\data\permission\ReverseRightLookupInterface;
+use oat\generis\test\MockObject;
+use oat\generis\test\TestCase;
+use oat\oatbox\user\User;
+use oat\tao\elasticsearch\IndexerInterface;
+use oat\tao\elasticsearch\Specification\UseAclSpecification;
+
+interface PermissionMock extends PermissionInterface, ReverseRightLookupInterface {
+}
+
+class UseAclSpecificationTest extends TestCase
+{
+    /** @var UseAclSpecification */
+    private $subject;
+
+    /** @var User|MockObject */
+    private $user;
+
+    protected function setUp(): void
+    {
+        $this->user = $this->createMock(User::class);
+        $this->subject = new UseAclSpecification();
+    }
+
+    /**
+     * @dataProvider isSatisfiedByProvider
+     */
+    public function testIsSatisfiedBy(bool $expected, array $config): void
+    {
+        $permission = $this->createMock($config['permissionClass']);
+        $permission->method('getPermissions')
+            ->willReturnCallback(
+                function ($user, $permissions) use ($config) {                    
+                    return [
+                        $permissions[0] => $config['permissions'],
+                    ];
+                }
+            );
+
+        $this->assertSame(
+            $expected,
+            $this->subject->isSatisfiedBy(
+                $config['index'],
+                $permission,
+                $this->user
+            )
+        );
+    }
+
+    public function isSatisfiedByProvider(): array
+    {
+        return [
+            'Must apply ACL if user DOES NOT have any access' => [
+                'expected' => true,
+                'config' => [
+                    'index' => IndexerInterface::ITEMS_INDEX,
+                    'permissionClass' => PermissionMock::class,
+                    'permissions' => []
+                ]
+            ],
+            'Must apply ACL if user DOES NOT have read access' => [
+                'expected' => true,
+                'config' => [
+                    'index' => IndexerInterface::ITEMS_INDEX,
+                    'permissionClass' => PermissionMock::class,
+                    'permissions' => [
+                        PermissionInterface::RIGHT_WRITE,
+                    ]
+                ]
+            ],
+            'Must NOT apply ACL if permission does not implement ' . ReverseRightLookupInterface::class => [
+                'expected' => false,
+                'config' => [
+                    'index' => IndexerInterface::ITEMS_INDEX,
+                    'permissionClass' => PermissionInterface::class,
+                    'permissions' => []
+                ]
+            ],
+            'Must NOT apply ACL if index does not support ACL' => [
+                'expected' => false,
+                'config' => [
+                    'index' => IndexerInterface::DELIVERIES_INDEX,
+                    'permissionClass' => PermissionMock::class,
+                    'permissions' => []
+                ]
+            ],
+            'Must NOT apply ACL if user HAVE read access' => [
+                'expected' => false,
+                'config' => [
+                    'index' => IndexerInterface::ITEMS_INDEX,
+                    'permissionClass' => PermissionMock::class,
+                    'permissions' => [
+                        PermissionInterface::RIGHT_READ,
+                    ]
+                ]
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/ADF-913

The goal here is to make the ACL validation for search query only required if the user has no Admin or DacSimple administrator rights.

The idea is to simulate a 'fake' permission check that will only work in case the user is a TaoDacSimple administrator.

TODO

- [x] Unit tests