### PR TITLE
fix/ADF-927: Escape backslashes in search queries

### DIFF
--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -84,6 +84,12 @@ class QueryBuilder extends ConfigurableService
         return $this;
     }
 
+    private const QUERY_STRING_REPLACEMENTS = [
+        '"' => '',
+        '\'' => '',
+        '\\' => '\\\\'
+    ];
+
     public static function create(): self
     {
         return new self();
@@ -91,12 +97,17 @@ class QueryBuilder extends ConfigurableService
 
     public function getSearchParams(string $queryString, string $type, int $start, int $count, string $order, string $dir): array
     {
-        $queryString = str_replace(['"', '\''], '', $queryString);
+        $queryString = str_replace(
+            array_keys(self::QUERY_STRING_REPLACEMENTS),
+            array_values(self::QUERY_STRING_REPLACEMENTS),
+            $queryString
+        );
+
         $queryString = htmlspecialchars_decode($queryString);
         $blocks = preg_split( '/( AND )/i', $queryString);
         $index = $this->getIndexByType($type);
         $conditions = $this->buildConditions($index, $blocks);
-        
+
         $query = [
             'query' => [
                 'query_string' =>

--- a/test/QueryBuilderTest.php
+++ b/test/QueryBuilderTest.php
@@ -158,6 +158,10 @@ class QueryBuilderTest extends TestCase
                 'delivery: https://test-act.docker.localhost/ontologies/tao.rdf#i5f200ed20e80a8c259ebe410db7f6a',
                 '{"query":{"query_string":{"default_operator":"AND","query":"(delivery:\"https:\/\/test-act.docker.localhost\/ontologies\/tao.rdf#i5f200ed20e80a8c259ebe410db7f6a\") AND (read_access:(\"https:\/\/tao.docker.localhost\/ontologies\/tao.rdf#i5f64514f1c36110793759fc28c0105b\" OR \"http:\/\/www.tao.lu\/Ontologies\/TAOItem.rdf#BackOfficeRole\" OR \"http:\/\/www.tao.lu\/Ontologies\/TAOItem.rdf#ItemsManagerRole\"))"}},"sort":{"_id":{"order":"DESC"}}}'
             ],
+            'Query term with a backslash' => [
+                'some\ term',
+                '{"query":{"query_string":{"default_operator":"AND","query":"(\"some\\\\\\\\ term\") AND (read_access:(\"https:\/\/tao.docker.localhost\/ontologies\/tao.rdf#i5f64514f1c36110793759fc28c0105b\" OR \"http:\/\/www.tao.lu\/Ontologies\/TAOItem.rdf#BackOfficeRole\" OR \"http:\/\/www.tao.lu\/Ontologies\/TAOItem.rdf#ItemsManagerRole\"))"}},"sort":{"_id":{"order":"DESC"}}}'
+            ],
         ];
     }
 

--- a/test/QueryBuilderTest.php
+++ b/test/QueryBuilderTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -14,7 +15,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2020-2021 (original work) Open Assessment Technologies SA;
+ * Copyright (c) 2020-2022 (original work) Open Assessment Technologies SA;
  */
 
 declare(strict_types=1);

--- a/test/QueryBuilderTest.php
+++ b/test/QueryBuilderTest.php
@@ -159,7 +159,7 @@ class QueryBuilderTest extends TestCase
             ],
         ];
     }
-    
+
     /**
      * @dataProvider queryResultsWithoutAccessControl
      */


### PR DESCRIPTION
**Associated Jira issue:** [ADF-927](https://oat-sa.atlassian.net/browse/ADF-927)

This fix makes user queries like `some\ term` to be sent to ES as `some\\ term`, so the slash is actually sent escaped as part of the query content itself. 

The tricky syntax that can be found in the unit test (`some\\\\\\\\ term`) is then escaped by PHP to `some\\\\ term` which, as it is part of a JSON string, is then translated by ES to `some\\ term` which, finally, should make ES to handle the slash as part of the query string itself.

- [x] Rebase with `develop`